### PR TITLE
Fix retrieval of int64 field values by name

### DIFF
--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -393,7 +393,7 @@ long long CppSQLite3Query::getInt64Field(int nField, long long nNullValue/*=0*/)
 long long CppSQLite3Query::getInt64Field(const char* szField, long long nNullValue/*=0*/)
 {
     int nField = fieldIndex(szField);
-    return getIntField(nField, nNullValue);
+    return getInt64Field(nField, nNullValue);
 }
 
 


### PR DESCRIPTION
There was a misstake made in the method that retrieves field values of type
int64 from queries given the name of the field. The method was erroenously
calling the int32 version of the method, resulting in a narrowing convert
warning.