### PR TITLE
Properly escape table names

### DIFF
--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -1166,11 +1166,10 @@ CppSQLite3Statement CppSQLite3DB::compileStatement(const char* szSQL)
 
 bool CppSQLite3DB::tableExists(const char* szTable)
 {
-    char szSQL[128];
-    sprintf(szSQL,
-            "select count(*) from sqlite_master where type='table' and name='%s'",
-            szTable);
-    int nRet = execScalar(szSQL);
+    CppSQLite3Buffer sql;
+    sql.format( "select count(*) from sqlite_master where type='table' and name=%Q",
+                szTable );
+    int nRet = execScalar(sql);
     return (nRet > 0);
 }
 


### PR DESCRIPTION
The method CppSQLite3DB::tableExist was not escaping the table names in the
sql query properly, which caused exceptions when the table name contains
quotes.

The fix was simply to change the string formatting to use the sqlite specific
printf variant (through CppSQLite3Buffer) with a %Q. This has the nice side
effect of also removing a warning when building with visual studio.