### PR TITLE
Change include guard macro

### DIFF
--- a/CppSQLite3.h
+++ b/CppSQLite3.h
@@ -5,8 +5,8 @@
  * See LICENSE file for copyright and license info
 */
 
-#ifndef _CppSQLite3_H_
-#define _CppSQLite3_H_
+#ifndef CppSQLite3_H
+#define CppSQLite3_H
 
 #include <sqlite3.h>
 #include <cstdio>


### PR DESCRIPTION
According to the C++ standard (§2.10.3.1), identifiers beginning with an
underscore and followed by a uppercase letter is reserved to the impelemntation
for any use. Hence the removal of the underscore in the unclude guard
definition.