### PR TITLE
Don't change content of CppSQLite3Buffer if exception is thrown in format()

### DIFF
--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -215,7 +215,7 @@ const char* CppSQLite3Buffer::format(const char* szFormat, ...)
         va_end(va);
         throw;
     }
-    mBuf = tmpBuf;
+    mBuf = std::move(tmpBuf);
     return static_cast<const char*>(mBuf.getBuffer());
 }
 

--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -202,20 +202,21 @@ void CppSQLite3Buffer::clear()
 
 const char* CppSQLite3Buffer::format(const char* szFormat, ...)
 {
-    clear();
     va_list va;
+    detail::SQLite3Memory tmpBuf; 
     try
     {
         va_start(va, szFormat);
-        mBuf = detail::SQLite3Memory(szFormat, va);
+        tmpBuf = detail::SQLite3Memory(szFormat, va);
         va_end(va);
-        return static_cast<const char*>(mBuf.getBuffer());
     }
     catch(CppSQLite3Exception&)
     {
         va_end(va);
         throw;
     }
+    mBuf = tmpBuf;
+    return static_cast<const char*>(mBuf.getBuffer());
 }
 
 


### PR DESCRIPTION
This keeps the internal buffer unmodified in case any exception is thrown during execution of format().
This change also allows for constructs like:

```
const char *foo = "foo";
...
CppSQLite3Buffer b;
b.format("CREATE TABLE %s (id INTEGER PRIMARY KEY AUTOINCREMENT);", foo)
...
b.format("%s;"
         "INSERT INTO %s DEFAULT VALUES;",
         b.get(), foo)
```
