### PR TITLE
Add getDoubleField API and update getFloatField API

### DIFF
--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -481,11 +481,31 @@ long long CppSQLite3Query::getInt64Field(const char* szField, long long nNullVal
 }
 
 
-double CppSQLite3Query::getFloatField(int nField, double fNullValue/*=0.0*/) const
+float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0*/) const
 {
     if (fieldDataType(nField) == SQLITE_NULL)
     {
         return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(sqlite3_column_double(mpVM, nField));
+    }
+}
+
+
+float CppSQLite3Query::getFloatField(const char* szField, float fNullValue/*=0.0*/) const
+{
+    int nField = fieldIndex(szField);
+    return getFloatField(nField, fNullValue);
+}
+
+
+double CppSQLite3Query::getDoubleField(int nField, double dNullValue/*=0.0*/) const
+{
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return dNullValue;
     }
     else
     {
@@ -494,10 +514,10 @@ double CppSQLite3Query::getFloatField(int nField, double fNullValue/*=0.0*/) con
 }
 
 
-double CppSQLite3Query::getFloatField(const char* szField, double fNullValue/*=0.0*/) const
+double CppSQLite3Query::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
 {
     int nField = fieldIndex(szField);
-    return getFloatField(nField, fNullValue);
+    return getDoubleField(nField, dNullValue);
 }
 
 

--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -855,11 +855,37 @@ int CppSQLite3Table::getIntField(const char* szField, int nNullValue/*=0*/) cons
 }
 
 
-double CppSQLite3Table::getFloatField(int nField, double fNullValue/*=0.0*/) const
+float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0*/) const
 {
     if (fieldIsNull(nField))
     {
         return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(atof(fieldValue(nField)));
+    }
+}
+
+
+float CppSQLite3Table::getFloatField(const char* szField, float fNullValue/*=0.0*/) const
+{
+    if (fieldIsNull(szField))
+    {
+        return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(atof(fieldValue(szField)));
+    }
+}
+
+
+double CppSQLite3Table::getDoubleField(int nField, double dNullValue/*=0.0*/) const
+{
+    if (fieldIsNull(nField))
+    {
+        return dNullValue;
     }
     else
     {
@@ -868,11 +894,11 @@ double CppSQLite3Table::getFloatField(int nField, double fNullValue/*=0.0*/) con
 }
 
 
-double CppSQLite3Table::getFloatField(const char* szField, double fNullValue/*=0.0*/) const
+double CppSQLite3Table::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
 {
     if (fieldIsNull(szField))
     {
-        return fNullValue;
+        return dNullValue;
     }
     else
     {

--- a/CppSQLite3.cpp
+++ b/CppSQLite3.cpp
@@ -481,7 +481,7 @@ long long CppSQLite3Query::getInt64Field(const char* szField, long long nNullVal
 }
 
 
-float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0*/) const
+float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0f*/) const
 {
     if (fieldDataType(nField) == SQLITE_NULL)
     {
@@ -494,7 +494,7 @@ float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0*/) const
 }
 
 
-float CppSQLite3Query::getFloatField(const char* szField, float fNullValue/*=0.0*/) const
+float CppSQLite3Query::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
 {
     int nField = fieldIndex(szField);
     return getFloatField(nField, fNullValue);
@@ -855,7 +855,7 @@ int CppSQLite3Table::getIntField(const char* szField, int nNullValue/*=0*/) cons
 }
 
 
-float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0*/) const
+float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0f*/) const
 {
     if (fieldIsNull(nField))
     {
@@ -868,7 +868,7 @@ float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0*/) const
 }
 
 
-float CppSQLite3Table::getFloatField(const char* szField, float fNullValue/*=0.0*/) const
+float CppSQLite3Table::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
 {
     if (fieldIsNull(szField))
     {

--- a/CppSQLite3.h
+++ b/CppSQLite3.h
@@ -163,8 +163,11 @@ public:
     long long getInt64Field(int nField, long long nNullValue=0) const;
     long long getInt64Field(const char* szField, long long nNullValue=0) const;
 
-    double getFloatField(int nField, double fNullValue=0.0) const;
-    double getFloatField(const char* szField, double fNullValue=0.0) const;
+    float getFloatField(int nField, float fNullValue=0.0f) const;
+    float getFloatField(const char* szField, float fNullValue=0.0f) const;
+
+    double getDoubleField(int nField, double dNullValue=0.0) const;
+    double getDoubleField(const char* szField, double dNullValue=0.0) const;
 
     const char* getStringField(int nField, const char* szNullValue="") const;
     const char* getStringField(const char* szField, const char* szNullValue="") const;

--- a/CppSQLite3.h
+++ b/CppSQLite3.h
@@ -222,11 +222,11 @@ public:
     int getIntField(int nField, int nNullValue=0) const;
     int getIntField(const char* szField, int nNullValue=0) const;
 
-    float getFloatField(int nField, float fNullValue=0.0) const;
-    float getFloatField(const char* szField, float fNullValue=0.0) const;
+    float getFloatField(int nField, float fNullValue=0.0f) const;
+    float getFloatField(const char* szField, float fNullValue=0.0f) const;
 
-    double getDoubleField(int nField, double dNullValue=0.0f) const;
-    double getDoubleField(const char* szField, double dNullValue=0.0f) const;
+    double getDoubleField(int nField, double dNullValue=0.0) const;
+    double getDoubleField(const char* szField, double dNullValue=0.0) const;
 
     const char* getStringField(int nField, const char* szNullValue="") const;
     const char* getStringField(const char* szField, const char* szNullValue="") const;

--- a/CppSQLite3.h
+++ b/CppSQLite3.h
@@ -222,8 +222,11 @@ public:
     int getIntField(int nField, int nNullValue=0) const;
     int getIntField(const char* szField, int nNullValue=0) const;
 
-    double getFloatField(int nField, double fNullValue=0.0) const;
-    double getFloatField(const char* szField, double fNullValue=0.0) const;
+    float getFloatField(int nField, float fNullValue=0.0) const;
+    float getFloatField(const char* szField, float fNullValue=0.0) const;
+
+    double getDoubleField(int nField, double dNullValue=0.0f) const;
+    double getDoubleField(const char* szField, double dNullValue=0.0f) const;
 
     const char* getStringField(int nField, const char* szNullValue="") const;
     const char* getStringField(const char* szField, const char* szNullValue="") const;


### PR DESCRIPTION
I wanted to expand the API here to have a getFloatField alongside the getDoubleField so that a cast to the end type was done automatically instead of requiring the caller to do so.

Tested with the following program that the getFloatFields return the correct data
sqlite test db
```sqlite
CREATE TABLE test (fVal real);
insert into test values (1.11);
insert into test values (1.5);
insert into test values (2);
insert into test values (20000000000);
insert into test values (-20000000000);
```
program
```cpp
#include "sqlite3.h"
#include "CppSQLite3.h"
#include <string>
#include <iomanip>
#include <iostream>
#include <cassert>

int main() {
	CppSQLite3DB conn;
	conn.open("test.sqlite");
	auto query = conn.execQuery("SELECT * FROM test");
	while (!query.eof()) {
		std::cout << std::setprecision(15) << query.getFloatField("fVal") << " " << query.getFloatField(0) << std::endl;
		assert(query.getFloatField("fVal") == query.getFloatField(0));
		query.nextRow();
	}
	return 0;
}
```
