### PR TITLE
Inherit std::exception for CppSQLite3Exception

### DIFF
--- a/CppSQLite3.h
+++ b/CppSQLite3.h
@@ -11,6 +11,7 @@
 #include <sqlite3.h>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 
 #define CPPSQLITE_ERROR 1000
 
@@ -59,7 +60,7 @@ namespace detail
 }
 
 
-class CppSQLite3Exception
+class CppSQLite3Exception : public std::exception
 {
 public:
 
@@ -74,6 +75,8 @@ public:
     const int errorCode() const { return mnErrCode; }
 
     const char* errorMessage() const { return mpszErrMess; }
+
+    const char* what() const noexcept override { return mpszErrMess; }
 
     static const char* errorCodeAsString(int nErrCode);
 


### PR DESCRIPTION
Fixes #13 

The following main.cc code catches the CppSQLite3Exception since it now would inherit std::exception
```cpp
#include "sqlite3.h"
#include "CppSQLite3.h"
#include <string>
#include <iomanip>
#include <iostream>
#include <cassert>

int main() {
	CppSQLite3DB conn;
	try {
		conn.open("test.sqlite");
		conn.compileStatement("select banana from 1");
	} catch (std::exception& e) {
		std::cout << e.what() << std::endl;
	}
	return 0;
}
```